### PR TITLE
fix: scope agenda-mode tagging to the vault

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,9 @@
 #+title: vulpea-para changelog
 
+* Unreleased
+
+- =vulpea-para-agenda-mode= now maintains the =agenda= tag only for files in your vault (under =vulpea-db-sync-directories=), so Org files you edit elsewhere are left alone. The scope is configurable through the new =vulpea-para-agenda-tag-scope=; set it to a function that always returns non-nil to tag every Org buffer as before.
+
 * v0.1.0
 
 The first working version, extracted from a personal PARA setup run since 2024 and rebuilt to be tested and explained.

--- a/README.org
+++ b/README.org
@@ -55,6 +55,8 @@ The self-updating agenda:
           (not (vulpea-note-tagged-any-p note "cemetery"))))
 #+end_src
 
+By default the mode only tags files in your vault (under =vulpea-db-sync-directories=), so the Org files you edit elsewhere never pick up an =agenda= tag. Point =vulpea-para-agenda-tag-scope= at a different predicate to widen or narrow that.
+
 Your agenda dispatcher, assembled from the building blocks (this stays in your config; vulpea-para only provides the pieces):
 
 #+begin_src emacs-lisp

--- a/docs/getting-started.org
+++ b/docs/getting-started.org
@@ -54,7 +54,7 @@ The category is what makes your agenda read "Blog > Ship the v2.1 post" instead 
 
 * The agenda that builds itself
 
-Here is the part that scales. Walking thousands of notes to find the few with tasks is hopeless, so =vulpea-para= does not. Whenever you save a note, it checks whether the file holds any open work and tags it =agenda= when it does, dropping the tag when the last task is done. Your =org-agenda-files= is then just the set of files carrying that tag, fetched from the database in a few milliseconds. A file slips in and out of your agenda on its own as work appears and finishes, and you never maintain a list of agenda files again.
+Here is the part that scales. Walking thousands of notes to find the few with tasks is hopeless, so =vulpea-para= does not. Whenever you save a note, it checks whether the file holds any open work and tags it =agenda= when it does, dropping the tag when the last task is done. Your =org-agenda-files= is then just the set of files carrying that tag, fetched from the database in a few milliseconds. A file slips in and out of your agenda on its own as work appears and finishes, and you never maintain a list of agenda files again. Only notes in your vault are watched this way, so the Org files you edit elsewhere stay untouched (=vulpea-para-agenda-tag-scope= controls that boundary).
 
 =setup-defaults= turned this on (it is =vulpea-para-agenda-mode= underneath) and gave you a dispatcher. Three commands open views into it:
 

--- a/test/vulpea-para-test.el
+++ b/test/vulpea-para-test.el
@@ -216,6 +216,49 @@
       (should-not (member "agenda" tags))
       (should (member "area" tags)))))
 
+(ert-deftest vulpea-para-vault-buffer-p-test ()
+  "Only files under `vulpea-db-sync-directories' count as vault buffers."
+  (let ((vulpea-db-sync-directories (list "/tmp/vault")))
+    ;; a file inside the vault
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/vault/note.org")
+      (should (vulpea-para-vault-buffer-p)))
+    ;; a sibling that merely shares a name prefix is not the vault
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/vault-of-doom/note.org")
+      (should-not (vulpea-para-vault-buffer-p)))
+    ;; a file somewhere else entirely
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/elsewhere/readme.org")
+      (should-not (vulpea-para-vault-buffer-p)))
+    ;; a buffer with no file at all
+    (with-temp-buffer
+      (should-not (vulpea-para-vault-buffer-p))))
+  ;; with no vault configured, nothing counts as in the vault
+  (let ((vulpea-db-sync-directories nil))
+    (with-temp-buffer
+      (setq buffer-file-name "/tmp/vault/note.org")
+      (should-not (vulpea-para-vault-buffer-p)))))
+
+(ert-deftest vulpea-para-maybe-update-agenda-tag-scope-test ()
+  "The save-time updater only tags buffers the scope predicate accepts."
+  ;; scope rejects the buffer -> no agenda tag even with open work
+  (let ((vulpea-para-agenda-tag-scope #'ignore))
+    (with-temp-buffer
+      (org-mode)
+      (insert "#+title: A\n\n* TODO do it\n")
+      (vulpea-para--maybe-update-agenda-tag)
+      (goto-char (point-min))
+      (should-not (member "agenda" (vulpea-buffer-tags-get t)))))
+  ;; scope accepts the buffer -> the tag is maintained as usual
+  (let ((vulpea-para-agenda-tag-scope (lambda () t)))
+    (with-temp-buffer
+      (org-mode)
+      (insert "#+title: A\n\n* TODO do it\n")
+      (vulpea-para--maybe-update-agenda-tag)
+      (goto-char (point-min))
+      (should (member "agenda" (vulpea-buffer-tags-get t))))))
+
 (ert-deftest vulpea-para-agenda-files-test ()
   "Agenda files are the paths of notes carrying the agenda tag."
   (vulpea-para-test--with-temp-db

--- a/vulpea-para-agenda.el
+++ b/vulpea-para-agenda.el
@@ -33,6 +33,8 @@
 (require 'vulpea-para-core)
 (require 'vulpea-para-db)
 
+(defvar vulpea-db-sync-directories)     ; defined in vulpea-db-sync
+
 (defcustom vulpea-para-open-work-tags '("REFILE")
   "Tags that always count as open work, whatever the TODO state.
 
@@ -218,18 +220,54 @@ Handy in `org-agenda-prefix-format', for example:
                         (t "Q4"))))
     (format "%02d%s" yy quarter)))
 
+(defun vulpea-para-vault-buffer-p ()
+  "Return non-nil when the current buffer visits a file in your vault.
+
+A file is in the vault when it lives under one of
+`vulpea-db-sync-directories'.  This is the default scope for
+`vulpea-para-agenda-mode', so Org files you edit outside your notes are
+never touched."
+  (when-let* ((file (buffer-file-name))
+              (dirs (bound-and-true-p vulpea-db-sync-directories)))
+    (let ((file (expand-file-name file)))
+      (seq-some
+       (lambda (dir)
+         (string-prefix-p (file-name-as-directory (expand-file-name dir))
+                          file))
+       dirs))))
+
+(defcustom vulpea-para-agenda-tag-scope #'vulpea-para-vault-buffer-p
+  "Predicate choosing which buffers `vulpea-para-agenda-mode' tags on save.
+
+Called with no arguments in the buffer about to be saved; non-nil means
+maintain the agenda tag here.  The default, `vulpea-para-vault-buffer-p',
+limits tagging to files in your vulpea vault, so Org files elsewhere
+never pick up an agenda tag.  To tag every Org buffer instead, set this
+to a function that always returns non-nil."
+  :type 'function
+  :group 'vulpea-para)
+
+(defun vulpea-para--maybe-update-agenda-tag ()
+  "Update the agenda tag, subject to `vulpea-para-agenda-tag-scope'.
+
+This is what `vulpea-para-agenda-mode' runs on `before-save-hook'."
+  (when (funcall vulpea-para-agenda-tag-scope)
+    (vulpea-para-update-agenda-tag)))
+
 (defun vulpea-para--install-save-hook ()
   "Install the agenda-tag updater on save in the current buffer."
-  (add-hook 'before-save-hook #'vulpea-para-update-agenda-tag nil t))
+  (add-hook 'before-save-hook #'vulpea-para--maybe-update-agenda-tag nil t))
 
 ;;;###autoload
 (define-minor-mode vulpea-para-agenda-mode
   "Keep the PARA agenda fast and self-updating.
 
-When on, every Org buffer maintains its agenda tag on save, and
+When on, Org buffers in your vault maintain their agenda tag on save, and
 `org-agenda-files' is refreshed from the database before each agenda or
-todo list is built.  You wire this up once; after that a file slips in
-and out of the agenda on its own as work appears and finishes."
+todo list is built.  The tagging scope is `vulpea-para-agenda-tag-scope',
+which limits it to your vault by default so files elsewhere are left
+alone.  You wire this up once; after that a file slips in and out of the
+agenda on its own as work appears and finishes."
   :global t
   :group 'vulpea-para
   (if vulpea-para-agenda-mode


### PR DESCRIPTION
`vulpea-para-agenda-mode` added its agenda-tagging `before-save-hook` to every Org buffer, so editing any Org file outside the note vault would wrongly pick up an `agenda` filetag. That made the mode unsafe to turn on for anyone who also edits Org files elsewhere.

This scopes the save-time tagging to the vault:

- `vulpea-para-vault-buffer-p` returns non-nil only for files under `vulpea-db-sync-directories`.
- `vulpea-para-agenda-tag-scope` is a new defcustom (default that predicate) deciding which buffers get tagged on save. Set it to a function that always returns non-nil to restore the previous tag-every-buffer behavior.
- The mode installs a scoped wrapper that consults the predicate; `vulpea-para-update-agenda-tag` itself is unchanged, so calling it directly still tags the current buffer unconditionally.

README, getting-started, and CHANGELOG updated to match.