### PR TITLE
feat: round out setup-defaults (named agenda buffer, meeting clock-in)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -3,6 +3,8 @@
 * Unreleased
 
 - =vulpea-para-agenda-mode= now maintains the =agenda= tag only for files in your vault (under =vulpea-db-sync-directories=), so Org files you edit elsewhere are left alone. The scope is configurable through the new =vulpea-para-agenda-tag-scope=; set it to a function that always returns non-nil to tag every Org buffer as before.
+- =vulpea-para-setup-defaults= now names the main agenda buffer through the new =vulpea-para-agenda-main-buffer-name= (default ="*PARA agenda*"=) instead of leaving it as the shared ="*Org Agenda*"=. Set it before calling setup-defaults to use your own.
+- =vulpea-para-setup-defaults='s meeting capture template now clocks in (=:clock-in t :clock-resume t=), matching how a meeting is usually captured while it happens.
 
 * v0.1.0
 

--- a/README.org
+++ b/README.org
@@ -39,7 +39,7 @@ The [[file:docs/getting-started.org][getting started guide]] walks through setti
 
 * Wiring it into your config
 
-The fast path: call =(vulpea-para-setup-defaults)= and you get a working setup out of the box, a default agenda dispatcher, the =Area > Project= prefix, capture templates, and the self-updating agenda turned on.
+The fast path: call =(vulpea-para-setup-defaults)= and you get a working setup out of the box, a default agenda dispatcher in its own buffer (=vulpea-para-agenda-main-buffer-name=), the =Area > Project= prefix, capture templates, and the self-updating agenda turned on.
 
 It is opt-in, though: vulpea-para never sets an org variable on its own. Skip =setup-defaults= and assemble the pieces yourself, so your agenda and capture layout stays exactly yours. Here is the full version.
 

--- a/test/vulpea-para-test.el
+++ b/test/vulpea-para-test.el
@@ -470,14 +470,24 @@
 (ert-deftest vulpea-para-setup-defaults-test ()
   "Setup-defaults installs the agenda commands and capture templates."
   (cl-letf (((symbol-function 'vulpea-para-agenda-mode) #'ignore))
-    (let (org-agenda-custom-commands
+    (let ((vulpea-para-agenda-main-buffer-name "*test agenda*")
+          org-agenda-custom-commands
           org-agenda-prefix-format
           org-capture-templates)
       (vulpea-para-setup-defaults)
       (should (assoc " " org-agenda-custom-commands))
       (should (assoc "p" org-capture-templates))
       (should (assoc "m" org-capture-templates))
-      (should org-agenda-prefix-format))))
+      (should org-agenda-prefix-format)
+      ;; the main command names its buffer from the configurable default
+      (should (equal (cadr (assq 'org-agenda-buffer-name
+                                 (nth 3 (assoc " " org-agenda-custom-commands))))
+                     "*test agenda*"))
+      ;; meetings clock in on capture
+      (should (plist-get (nthcdr 5 (assoc "m" org-capture-templates))
+                         :clock-in))
+      (should (plist-get (nthcdr 5 (assoc "m" org-capture-templates))
+                         :clock-resume)))))
 
 (provide 'vulpea-para-test)
 ;;; vulpea-para-test.el ends here

--- a/vulpea-para-agenda.el
+++ b/vulpea-para-agenda.el
@@ -303,6 +303,16 @@ You define that command in your own `org-agenda-custom-commands'."
   :type 'string
   :group 'vulpea-para)
 
+(defcustom vulpea-para-agenda-main-buffer-name "*PARA agenda*"
+  "Buffer name for the agenda built by `vulpea-para-setup-defaults'.
+
+The dispatcher that `vulpea-para-setup-defaults' installs binds
+`org-agenda-buffer-name' to this, so the main agenda gets a stable,
+recognizable name instead of the shared `*Org Agenda*'.  Set it before
+calling `vulpea-para-setup-defaults' to use your own."
+  :type 'string
+  :group 'vulpea-para)
+
 ;;;; Skip functions (for `org-agenda-skip-function')
 
 (defun vulpea-para-agenda-skip-habits ()

--- a/vulpea-para.el
+++ b/vulpea-para.el
@@ -81,8 +81,9 @@ working agenda and capture out of the box.
 
 It overwrites `org-agenda-custom-commands' and
 `org-agenda-prefix-format', and appends to `org-capture-templates'.
-Skip it and wire things by hand if you want full control over the
-layout (see the README)."
+The main agenda is named with `vulpea-para-agenda-main-buffer-name', and
+the meeting template clocks in.  Skip it and wire things by hand if you
+want full control over the layout (see the README)."
   (vulpea-para-agenda-mode 1)
   (setq org-agenda-custom-commands
         `((" " "PARA agenda"
@@ -91,7 +92,8 @@ layout (see the README)."
             ,vulpea-para-agenda-cmd-focus
             ,vulpea-para-agenda-cmd-stuck-projects
             ,vulpea-para-agenda-cmd-waiting
-            ,(vulpea-para-agenda-cmd-current-quarter)))))
+            ,(vulpea-para-agenda-cmd-current-quarter))
+           ((org-agenda-buffer-name ,vulpea-para-agenda-main-buffer-name)))))
   (setq org-agenda-prefix-format
         '((agenda . " %(vulpea-para-agenda-category 36) %?-12t %12s")
           (todo   . " %(vulpea-para-agenda-category 36) ")
@@ -105,7 +107,8 @@ layout (see the README)."
             (function vulpea-para-capture-project-template))
            ("m" "PARA meeting" entry
             (function vulpea-para-capture-meeting-target)
-            (function vulpea-para-capture-meeting-template))))))
+            (function vulpea-para-capture-meeting-template)
+            :clock-in t :clock-resume t)))))
 
 (provide 'vulpea-para)
 ;;; vulpea-para.el ends here


### PR DESCRIPTION
`setup-defaults` is meant to be the battle-tested setup, extracted, but it had drifted from it in two ways that made adopting it a downgrade:

- the main agenda opened in the shared `*Org Agenda*` buffer rather than a recognizable one;
- the meeting capture template did not clock in.

This closes both:

- New `vulpea-para-agenda-main-buffer-name` defcustom (default `*PARA agenda*`). `setup-defaults` binds `org-agenda-buffer-name` to it in the main dispatcher. Set it before calling `setup-defaults` to pick your own.
- The `m` meeting template gains `:clock-in t :clock-resume t`, so capturing a meeting clocks into it (a meeting is usually captured while it happens).

README and CHANGELOG updated.