### PR TITLE
fix: keep vulpea-para-agenda-area scoped to its file

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -5,6 +5,7 @@
 - =vulpea-para-agenda-mode= now maintains the =agenda= tag only for files in your vault (under =vulpea-db-sync-directories=), so Org files you edit elsewhere are left alone. The scope is configurable through the new =vulpea-para-agenda-tag-scope=; set it to a function that always returns non-nil to tag every Org buffer as before.
 - =vulpea-para-setup-defaults= now names the main agenda buffer through the new =vulpea-para-agenda-main-buffer-name= (default ="*PARA agenda*"=) instead of leaving it as the shared ="*Org Agenda*"=. Set it before calling setup-defaults to use your own.
 - =vulpea-para-setup-defaults='s meeting capture template now clocks in (=:clock-in t :clock-resume t=), matching how a meeting is usually captured while it happens.
+- =vulpea-para-agenda-area= now stays restricted to the chosen area's file. With =vulpea-para-agenda-mode= on, its =org-agenda= advice reset =org-agenda-files= mid-command and the view listed every task; the refresh is now skipped while the new =vulpea-para-agenda-inhibit-files-update= variable is bound, which the command does.
 
 * v0.1.0
 

--- a/test/vulpea-para-test.el
+++ b/test/vulpea-para-test.el
@@ -277,6 +277,19 @@
       (vulpea-para-agenda-files-update)
       (should (equal '("/tmp/blog.org") org-agenda-files)))))
 
+(ert-deftest vulpea-para-agenda-files-update-inhibit-test ()
+  "Updating is a no-op while `vulpea-para-agenda-inhibit-files-update'.
+
+This is what keeps `vulpea-para-agenda-area' scoped to one file even
+though the agenda-mode advice runs on every `org-agenda' call."
+  (vulpea-para-test--with-temp-db
+    (vulpea-para-test--insert "a1" "Blog" :level 0 :tags '("agenda")
+                              :path "/tmp/blog.org")
+    (let ((org-agenda-files '("/tmp/area.org"))
+          (vulpea-para-agenda-inhibit-files-update t))
+      (vulpea-para-agenda-files-update)
+      (should (equal '("/tmp/area.org") org-agenda-files)))))
+
 ;;; Capture
 
 (ert-deftest vulpea-para-category-test ()

--- a/vulpea-para-agenda.el
+++ b/vulpea-para-agenda.el
@@ -111,12 +111,21 @@ is set, notes it rejects are left out."
       (setq notes (seq-filter vulpea-para-agenda-files-filter notes)))
     (seq-uniq (mapcar #'vulpea-note-path notes))))
 
+(defvar vulpea-para-agenda-inhibit-files-update nil
+  "When non-nil, `vulpea-para-agenda-files-update' leaves files alone.
+
+Bind it around an `org-agenda' call that sets `org-agenda-files' itself,
+so the agenda-mode advice does not overwrite the restriction.
+`vulpea-para-agenda-area' binds it to stay scoped to a single file.")
+
 (defun vulpea-para-agenda-files-update (&rest _)
   "Set `org-agenda-files' to the PARA agenda files.
 
 Ignores its arguments, so it works as :before advice on `org-agenda'
-and `org-todo-list'."
-  (setq org-agenda-files (vulpea-para-agenda-files)))
+and `org-todo-list'.  Does nothing while
+`vulpea-para-agenda-inhibit-files-update' is non-nil."
+  (unless vulpea-para-agenda-inhibit-files-update
+    (setq org-agenda-files (vulpea-para-agenda-files))))
 
 ;;; Agenda predicates (operate on the heading at point)
 ;;
@@ -497,11 +506,13 @@ the notes tagged with `vulpea-para-people-tag'."
   "Show a TODO agenda restricted to a selected area's file.
 
 `org-agenda-files' is bound to the area's file only for the duration of
-the command; nothing is set permanently."
+the command; nothing is set permanently.  The agenda-mode files update
+is inhibited so it does not widen the scope back to every agenda file."
   (interactive)
   (let* ((area (vulpea-select-from "Area" (vulpea-para-areas)
                                    :require-match t))
-         (org-agenda-files (list (vulpea-note-path area))))
+         (org-agenda-files (list (vulpea-note-path area)))
+         (vulpea-para-agenda-inhibit-files-update t))
     (org-agenda nil "t")))
 
 (provide 'vulpea-para-agenda)


### PR DESCRIPTION
`vulpea-para-agenda-area` binds `org-agenda-files` to the chosen area's file and calls `org-agenda`. But with `vulpea-para-agenda-mode` enabled, its `:before` advice `vulpea-para-agenda-files-update` runs inside that call and resets `org-agenda-files` to the full agenda query, so the area view listed every task regardless of area.

Fix: add `vulpea-para-agenda-inhibit-files-update`. `vulpea-para-agenda-files-update` is a no-op while it is non-nil, and `vulpea-para-agenda-area` binds it alongside its `org-agenda-files` restriction. The variable is public, so any custom file-restricted agenda command can use the same guard.