### PR TITLE
feat: pin files onto the agenda with vulpea-para-open-work-files

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -6,6 +6,7 @@
 - =vulpea-para-setup-defaults= now names the main agenda buffer through the new =vulpea-para-agenda-main-buffer-name= (default ="*PARA agenda*"=) instead of leaving it as the shared ="*Org Agenda*"=. Set it before calling setup-defaults to use your own.
 - =vulpea-para-setup-defaults='s meeting capture template now clocks in (=:clock-in t :clock-resume t=), matching how a meeting is usually captured while it happens.
 - =vulpea-para-agenda-area= now stays restricted to the chosen area's file. With =vulpea-para-agenda-mode= on, its =org-agenda= advice reset =org-agenda-files= mid-command and the view listed every task; the refresh is now skipped while the new =vulpea-para-agenda-inhibit-files-update= variable is bound, which the command does.
+- Files can be pinned onto the agenda through the new =vulpea-para-open-work-files=. A file listed there always counts as open work, so it keeps the =agenda= tag even when empty or all-done and never drops off the agenda, handy for an inbox you always want in view. Entries are bare file names (matched by base name), absolute file names, or predicates of the buffer's file name.
 
 * v0.1.0
 

--- a/README.org
+++ b/README.org
@@ -57,6 +57,12 @@ The self-updating agenda:
 
 By default the mode only tags files in your vault (under =vulpea-db-sync-directories=), so the Org files you edit elsewhere never pick up an =agenda= tag. Point =vulpea-para-agenda-tag-scope= at a different predicate to widen or narrow that.
 
+A file only earns the =agenda= tag while it holds open work, so an empty or all-done file drops off the agenda. To keep one on regardless, list it in =vulpea-para-open-work-files=; such a file always counts as open work. Entries are bare file names (matched by base name, so ="inbox.org"= matches wherever it lives), absolute file names, or predicates of the buffer's file name. Handy for an inbox you always want in view:
+
+#+begin_src emacs-lisp
+  (setq vulpea-para-open-work-files '("inbox.org" "inbox-dor.org"))
+#+end_src
+
 Your agenda dispatcher, assembled from the building blocks (this stays in your config; vulpea-para only provides the pieces):
 
 #+begin_src emacs-lisp

--- a/test/vulpea-para-test.el
+++ b/test/vulpea-para-test.el
@@ -197,6 +197,50 @@
     (insert "#+title: A\n\n* A note\n<2025-06-20 Fri>\n")
     (should (vulpea-para-buffer-open-work-p))))
 
+(ert-deftest vulpea-para-buffer-open-work-p-files-test ()
+  "A file in `vulpea-para-open-work-files' always counts as open work."
+  ;; a bare name matches by base name, wherever the file lives, even with
+  ;; no headings at all
+  (let ((vulpea-para-open-work-files '("inbox.org")))
+    (with-temp-buffer
+      (org-mode)
+      (setq buffer-file-name "/tmp/vault/inbox.org")
+      (insert "#+title: Inbox\n")
+      (should (vulpea-para-buffer-open-work-p))))
+  ;; a file not on the list with no open work still holds none
+  (let ((vulpea-para-open-work-files '("inbox.org")))
+    (with-temp-buffer
+      (org-mode)
+      (setq buffer-file-name "/tmp/vault/notes.org")
+      (insert "#+title: Notes\n\n* DONE done\n")
+      (should-not (vulpea-para-buffer-open-work-p))))
+  ;; an absolute entry matches that file, not a namesake elsewhere
+  (let ((vulpea-para-open-work-files '("/tmp/vault/inbox.org")))
+    (with-temp-buffer
+      (org-mode)
+      (setq buffer-file-name "/tmp/vault/inbox.org")
+      (insert "#+title: Inbox\n")
+      (should (vulpea-para-buffer-open-work-p)))
+    (with-temp-buffer
+      (org-mode)
+      (setq buffer-file-name "/tmp/other/inbox.org")
+      (insert "#+title: Inbox\n")
+      (should-not (vulpea-para-buffer-open-work-p))))
+  ;; a predicate entry is called with the buffer's absolute file name
+  (let ((vulpea-para-open-work-files
+         (list (lambda (f) (string-suffix-p "inbox-dor.org" f)))))
+    (with-temp-buffer
+      (org-mode)
+      (setq buffer-file-name "/tmp/vault/inbox-dor.org")
+      (insert "#+title: Inbox\n")
+      (should (vulpea-para-buffer-open-work-p))))
+  ;; a buffer with no file is unaffected
+  (let ((vulpea-para-open-work-files '("inbox.org")))
+    (with-temp-buffer
+      (org-mode)
+      (insert "#+title: A\n")
+      (should-not (vulpea-para-buffer-open-work-p)))))
+
 (ert-deftest vulpea-para-update-agenda-tag-test ()
   "The agenda tag is added or dropped to match the file's open work."
   ;; open work, no tag yet -> tag is added
@@ -215,6 +259,26 @@
     (let ((tags (vulpea-buffer-tags-get t)))
       (should-not (member "agenda" tags))
       (should (member "area" tags)))))
+
+(ert-deftest vulpea-para-update-agenda-tag-open-work-files-test ()
+  "A file in `vulpea-para-open-work-files' keeps the agenda tag with no TODO."
+  (let ((vulpea-para-open-work-files '("inbox.org")))
+    ;; listed, no open work, untagged -> the tag is added
+    (with-temp-buffer
+      (org-mode)
+      (setq buffer-file-name "/tmp/vault/inbox.org")
+      (insert "#+title: Inbox\n")
+      (vulpea-para-update-agenda-tag)
+      (goto-char (point-min))
+      (should (member "agenda" (vulpea-buffer-tags-get t))))
+    ;; listed, no open work, already tagged -> the tag stays
+    (with-temp-buffer
+      (org-mode)
+      (setq buffer-file-name "/tmp/vault/inbox.org")
+      (insert "#+title: Inbox\n#+filetags: :agenda:\n")
+      (vulpea-para-update-agenda-tag)
+      (goto-char (point-min))
+      (should (member "agenda" (vulpea-buffer-tags-get t))))))
 
 (ert-deftest vulpea-para-vault-buffer-p-test ()
   "Only files under `vulpea-db-sync-directories' count as vault buffers."
@@ -380,8 +444,12 @@ though the agenda-mode advice runs on every `org-agenda' call."
     ;; f3: tagged, no tasks at all -> stale
     (vulpea-para-test--insert "a3" "F3" :level 0 :tags '("agenda")
                               :path "/tmp/f3.org")
-    (should (equal '("/tmp/f2.org" "/tmp/f3.org")
-                   (sort (vulpea-para-doctor-stale-agenda-files) #'string<)))))
+    ;; inbox: tagged, no tasks, but pinned open -> kept, not stale
+    (vulpea-para-test--insert "a4" "Inbox" :level 0 :tags '("agenda")
+                              :path "/tmp/inbox.org")
+    (let ((vulpea-para-open-work-files '("inbox.org")))
+      (should (equal '("/tmp/f2.org" "/tmp/f3.org")
+                     (sort (vulpea-para-doctor-stale-agenda-files) #'string<))))))
 
 ;;; Archive
 

--- a/vulpea-para-agenda.el
+++ b/vulpea-para-agenda.el
@@ -43,35 +43,74 @@ to be sorted) keeps its file on the agenda even with no open TODO."
   :type '(repeat string)
   :group 'vulpea-para)
 
+(defcustom vulpea-para-open-work-files nil
+  "Files that always count as holding open work.
+
+A file matched here keeps the `agenda' tag even with no open TODO, so it
+never drops off the agenda.  Handy for an inbox you always want in view,
+so you remember to empty it.
+
+Each entry is one of:
+- a bare file name with no directory, matched against the buffer file's
+  base name, so \"inbox.org\" matches wherever the inbox lives;
+- an absolute file name, matched against the buffer file;
+- a function of one argument, the buffer file's absolute name, returning
+  non-nil to match."
+  :type '(repeat (choice (file :tag "File name")
+                         (function :tag "Predicate")))
+  :group 'vulpea-para)
+
+(defun vulpea-para--open-work-path-p (path)
+  "Return non-nil when PATH is in `vulpea-para-open-work-files'.
+
+PATH is an absolute file name.  See `vulpea-para-open-work-files'."
+  (when path
+    (let ((path (expand-file-name path)))
+      (seq-some
+       (lambda (entry)
+         (cond
+          ((functionp entry) (funcall entry path))
+          ((file-name-absolute-p entry)
+           (string-equal (expand-file-name entry) path))
+          (t (string-equal entry (file-name-nondirectory path)))))
+       vulpea-para-open-work-files))))
+
+(defun vulpea-para--open-work-file-p ()
+  "Return non-nil when the current file is in `vulpea-para-open-work-files'."
+  (vulpea-para--open-work-path-p (buffer-file-name)))
+
 (defun vulpea-para-buffer-open-work-p ()
   "Return non-nil when there is any open work in the current buffer.
 
-Open work is any of: a not-done TODO heading; a heading tagged with one
-of `vulpea-para-open-work-tags'; or a not-done heading carrying an
-active timestamp (something with a date still ahead of it).  A buffer
-with only DONE or plain headings, or no headings at all, holds none."
-  (org-element-map (org-element-parse-buffer 'headline) 'headline
-    (lambda (h)
-      (let ((todo-type (org-element-property :todo-type h)))
-        (or
-         (eq 'todo todo-type)
-         (seq-intersection (org-element-property :tags h)
-                           vulpea-para-open-work-tags)
-         (and
-          (not (eq 'done todo-type))
-          (org-element-property :contents-begin h)
-          (save-excursion
-            (goto-char (org-element-property :contents-begin h))
-            ;; look for an active timestamp before the next heading, not
-            ;; in child subtrees (which :contents-end would include)
-            (let ((end (save-excursion
-                         (or (re-search-forward
-                              org-element-headline-re
-                              (org-element-property :contents-end h)
-                              t)
-                             (org-element-property :contents-end h)))))
-              (re-search-forward org-ts-regexp end t)))))))
-    nil 'first-match))
+Open work is any of: the file is one of `vulpea-para-open-work-files'; a
+not-done TODO heading; a heading tagged with one of
+`vulpea-para-open-work-tags'; or a not-done heading carrying an active
+timestamp (something with a date still ahead of it).  A buffer with only
+DONE or plain headings, or no headings at all, holds none."
+  (or
+   (vulpea-para--open-work-file-p)
+   (org-element-map (org-element-parse-buffer 'headline) 'headline
+     (lambda (h)
+       (let ((todo-type (org-element-property :todo-type h)))
+         (or
+          (eq 'todo todo-type)
+          (seq-intersection (org-element-property :tags h)
+                            vulpea-para-open-work-tags)
+          (and
+           (not (eq 'done todo-type))
+           (org-element-property :contents-begin h)
+           (save-excursion
+             (goto-char (org-element-property :contents-begin h))
+             ;; look for an active timestamp before the next heading, not
+             ;; in child subtrees (which :contents-end would include)
+             (let ((end (save-excursion
+                          (or (re-search-forward
+                               org-element-headline-re
+                               (org-element-property :contents-end h)
+                               t)
+                              (org-element-property :contents-end h)))))
+               (re-search-forward org-ts-regexp end t)))))))
+     nil 'first-match)))
 
 (defun vulpea-para-update-agenda-tag ()
   "Add or drop the agenda tag on the current file to match its open work.

--- a/vulpea-para-doctor.el
+++ b/vulpea-para-doctor.el
@@ -58,11 +58,14 @@ usually a leftover from moving things around by hand."
 
 These files carry the agenda tag but, as far as the database can tell,
 have no open work, so the tag is probably stale.  Saving the file fixes
-it; this just finds the drift."
+it; this just finds the drift.  Files pinned through
+`vulpea-para-open-work-files' are kept on purpose and never counted."
   (let ((open-paths (make-hash-table :test 'equal)))
     (dolist (note (vulpea-db-query #'vulpea-para--note-open-p))
       (puthash (vulpea-note-path note) t open-paths))
-    (seq-remove (lambda (path) (gethash path open-paths))
+    (seq-remove (lambda (path)
+                  (or (gethash path open-paths)
+                      (vulpea-para--open-work-path-p path)))
                 (vulpea-para-agenda-files))))
 
 ;;;###autoload


### PR DESCRIPTION
The `agenda` tag is derived state: on save vulpea-para adds or drops it to match whether the file holds open work, so an empty or all-done file falls off the agenda. That's usually what you want, but not for something like an inbox you always want to see even when it's empty, so you remember to process it.

This adds `vulpea-para-open-work-files`: list a file there and it always counts as open work, keeping the tag regardless of content. Entries can be bare file names (matched by base name, so `inbox.org` matches wherever it lives), absolute paths, or predicates of the buffer's file name.

The doctor's stale-agenda-tag check learned about these too, otherwise it'd flag a pinned-but-empty file as drift and wrongly suggest saving would fix it.