### PR TITLE
feat: refile across the whole vault, not just agenda files

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,8 @@
 
 * Unreleased
 
+- Refile now reaches the whole vault, not just the agenda files. The new =vulpea-para-refile-files= plugs into =org-refile-targets= (org accepts a function as the FILES part) and returns every live file-level note from the database, area files first; =vulpea-para-refile-files-filter= keeps unwanted notes out, and the new =vulpea-para-refile-verify-target= (for =org-refile-target-verify-function=) drops archived subtrees from the candidates. =vulpea-para-setup-defaults= wires all of it, including =org-refile-use-outline-path 'file= so a file itself is a valid target.
+
 - =vulpea-para-agenda-mode= now maintains the =agenda= tag only for files in your vault (under =vulpea-db-sync-directories=), so Org files you edit elsewhere are left alone. The scope is configurable through the new =vulpea-para-agenda-tag-scope=; set it to a function that always returns non-nil to tag every Org buffer as before.
 - =vulpea-para-setup-defaults= now names the main agenda buffer through the new =vulpea-para-agenda-main-buffer-name= (default ="*PARA agenda*"=) instead of leaving it as the shared ="*Org Agenda*"=. Set it before calling setup-defaults to use your own.
 - =vulpea-para-setup-defaults='s meeting capture template now clocks in (=:clock-in t :clock-resume t=), matching how a meeting is usually captured while it happens.

--- a/README.org
+++ b/README.org
@@ -29,6 +29,7 @@ And the nice part: these are facets, not walls. A note can be more than one at o
 
 - *Capture* into the right place without filing: a project under an area (=M-x vulpea-para-capture-project=), a new area (=M-x vulpea-para-capture-area=), and, through the Org capture building blocks (see below), tasks and meetings filed under the person they are about. Projects get a readable =Area > Project= category.
 - Lean on an *agenda that builds itself* from the notes that actually hold open work, in a few milliseconds even across thousands of notes: turn on =vulpea-para-agenda-mode=. Ready-made views come with it, =vulpea-para-agenda-main=, =-person=, and =-area=, plus command building blocks (=vulpea-para-agenda-cmd-*=) you splice into your own dispatcher.
+- *Refile* anywhere in the vault, right from the agenda: =vulpea-para-refile-files= feeds =org-refile-targets= every live note (areas first) instead of just the agenda files, and =vulpea-para-refile-verify-target= keeps archived subtrees out of the list.
 - *Find* an area, a project, or a resource: =vulpea-para-find-area= and friends.
 - *Archive* a finished project into its area: =M-x vulpea-para-archive-project=.
 - Keep the whole thing honest with =M-x vulpea-para-doctor=.
@@ -93,13 +94,30 @@ Capture, again assembled by you:
            (function vulpea-para-capture-project-template))))
 #+end_src
 
+Refile, so a captured task can reach any note in the vault, not only the files that already carry open work (with the self-updating agenda, =org-agenda-files= is only the notes that hold work, so building refile targets from it would be backwards; refiling is exactly how work reaches a note that had none):
+
+#+begin_src emacs-lisp
+  (setq org-refile-targets '((vulpea-para-refile-files :maxlevel . 3))
+        org-refile-use-outline-path 'file
+        org-outline-path-complete-in-steps nil
+        org-refile-allow-creating-parent-nodes 'confirm
+        org-refile-target-verify-function #'vulpea-para-refile-verify-target)
+
+  ;; and, like the agenda, the target list takes a filter
+  (setq vulpea-para-refile-files-filter
+        (lambda (note)
+          (not (vulpea-note-tagged-any-p note "cemetery"))))
+#+end_src
+
+Targets are every live file-level note, area files first; =org-refile-use-outline-path 'file= makes a file itself a valid target, so a task can land at the top of an area or resource that has no headings yet. The verify function drops archived subtrees from the candidate list.
+
 Then bind the commands you like: =vulpea-para-agenda-main=, =vulpea-para-agenda-person=, =vulpea-para-agenda-area=, =vulpea-para-capture-area=, =vulpea-para-capture-project=, =vulpea-para-find-area=, and the rest.
 
 * Architecture and roadmap
 
 vulpea-para is a library first: predicates, queries, and the capture, archive, and agenda flows, all reading from vulpea's database so they stay fast at ten thousand notes. The one place that touches a file at write time is the open-work check on save. It drives org's own agenda and capture rather than reinventing them, and its own surface stays small (the interactive commands and the doctor's report).
 
-The richer reactive views (active projects, areas gone quiet, the resources feeding a project, a browsable archive) are planned, and they will live here too, built on vui.el and vulpea-ui over this same read API. Also planned: schema validation of PARA structure, and fancier refiling.
+The richer reactive views (active projects, areas gone quiet, the resources feeding a project, a browsable archive) are planned, and they will live here too, built on vui.el and vulpea-ui over this same read API. Also planned: schema validation of PARA structure.
 
 * Status
 

--- a/docs/getting-started.org
+++ b/docs/getting-started.org
@@ -62,6 +62,12 @@ Here is the part that scales. Walking thousands of notes to find the few with ta
 - =vulpea-para-agenda-person= gathers everything about a chosen person, their meetings and the tasks tagged with their name.
 - =vulpea-para-agenda-area= narrows the agenda down to a single area's file.
 
+* Refiling into place
+
+Captured tasks pile up in an inbox, and the dispatcher's first block ("To refile") shows them. Press =C-c C-w= on one (in the agenda or in the file) and the target list covers your whole vault: every live note, area files first, by outline path. This matters because =org-agenda-files= is only the files that already hold open work; refiling is exactly how a task reaches a note that had none, so the targets come from the database instead. Archived subtrees stay out of the list.
+
+=setup-defaults= wires this up. If a note should never be offered as a target, point =vulpea-para-refile-files-filter= at a predicate that rejects it.
+
 * People and meetings
 
 A person is just a note tagged =people=, and meetings file themselves under the person they are about. Run =M-x org-capture= and press =m=, pick the person, and the meeting lands in their note. Later, =vulpea-para-agenda-person= pulls all of it back together.

--- a/test/vulpea-para-test.el
+++ b/test/vulpea-para-test.el
@@ -546,6 +546,50 @@ though the agenda-mode advice runs on every `org-agenda' call."
            (lambda (n) (not (vulpea-note-tagged-any-p n "cemetery")))))
       (should (equal '("/tmp/blog.org") (vulpea-para-agenda-files))))))
 
+;;; Refile
+
+(ert-deftest vulpea-para-refile-files-test ()
+  "Refile candidates are all live file-level notes, areas first.
+
+Archived files stay out, and heading-level notes add nothing on
+their own (org scans headings inside the returned files itself)."
+  (vulpea-para-test--with-temp-db
+    (vulpea-para-test--insert "r1" "Emacs" :level 0
+                              :path "/tmp/emacs.org")
+    (vulpea-para-test--insert "a1" "Blog" :level 0 :tags '("area")
+                              :path "/tmp/blog.org")
+    (vulpea-para-test--insert "x1" "Old" :level 0 :tags '("ARCHIVE")
+                              :path "/tmp/old.org")
+    (vulpea-para-test--insert "p1" "Ship v2" :level 1 :tags '("project")
+                              :path "/tmp/blog.org")
+    (should (equal '("/tmp/blog.org" "/tmp/emacs.org")
+                   (vulpea-para-refile-files)))))
+
+(ert-deftest vulpea-para-refile-files-filter-test ()
+  "The refile files filter keeps out notes it rejects."
+  (vulpea-para-test--with-temp-db
+    (vulpea-para-test--insert "a1" "Blog" :level 0 :tags '("area")
+                              :path "/tmp/blog.org")
+    (vulpea-para-test--insert "a2" "Dead" :level 0 :tags '("cemetery")
+                              :path "/tmp/dead.org")
+    (let ((vulpea-para-refile-files-filter
+           (lambda (n) (not (vulpea-note-tagged-any-p n "cemetery")))))
+      (should (equal '("/tmp/blog.org") (vulpea-para-refile-files))))))
+
+(ert-deftest vulpea-para-refile-verify-target-test ()
+  "Archived headings are not refile targets; their subtree is skipped."
+  (with-temp-buffer
+    (org-mode)
+    (insert "* Tasks\n* Old :ARCHIVE:\n** Child\n* Next\n")
+    (goto-char (point-min))
+    ;; a live heading is a valid target
+    (should (vulpea-para-refile-verify-target))
+    ;; an archived heading is not, and point jumps past its subtree
+    ;; so children are not offered either
+    (forward-line 1)
+    (should-not (vulpea-para-refile-verify-target))
+    (should (looking-at-p "\\* Next"))))
+
 ;;; Setup defaults
 
 (ert-deftest vulpea-para-setup-defaults-test ()
@@ -554,9 +598,22 @@ though the agenda-mode advice runs on every `org-agenda' call."
     (let ((vulpea-para-agenda-main-buffer-name "*test agenda*")
           org-agenda-custom-commands
           org-agenda-prefix-format
-          org-capture-templates)
+          org-capture-templates
+          org-refile-targets
+          org-refile-use-outline-path
+          org-outline-path-complete-in-steps
+          org-refile-allow-creating-parent-nodes
+          org-refile-target-verify-function)
       (vulpea-para-setup-defaults)
       (should (assoc " " org-agenda-custom-commands))
+      ;; refile sees the whole vault, by outline path, minus archives
+      (should (equal '((vulpea-para-refile-files :maxlevel . 3))
+                     org-refile-targets))
+      (should (eq 'file org-refile-use-outline-path))
+      (should-not org-outline-path-complete-in-steps)
+      (should (eq 'confirm org-refile-allow-creating-parent-nodes))
+      (should (eq #'vulpea-para-refile-verify-target
+                  org-refile-target-verify-function))
       (should (assoc "p" org-capture-templates))
       (should (assoc "m" org-capture-templates))
       (should org-agenda-prefix-format)

--- a/vulpea-para-refile.el
+++ b/vulpea-para-refile.el
@@ -1,0 +1,87 @@
+;;; vulpea-para-refile.el --- Refile across the whole vault -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2024-2026 Boris Buliga <boris@d12frosted.io>
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+;;
+;; URL: https://github.com/d12frosted/vulpea-para
+;;
+;; License: GPLv3
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;; Refile targets for the whole vault, not just the agenda.
+;;
+;; With the self-updating agenda, `org-agenda-files' is only the files
+;; that hold open work, so building refile targets from it would let you
+;; refile only into notes that already have work.  That is backwards:
+;; refiling is exactly how a task reaches a note that had none.
+;;
+;; The hook org provides is that the FILES part of an
+;; `org-refile-targets' entry may be a function.  `vulpea-para-refile-files'
+;; is that function: it asks the database for every live file-level note
+;; (areas first, then the rest), so refile from the agenda, or anywhere
+;; else, can reach the whole vault.  Pair it with
+;; `vulpea-para-refile-verify-target' to keep archived subtrees out:
+;;
+;;   (setq org-refile-targets \\='((vulpea-para-refile-files :maxlevel . 3))
+;;         org-refile-use-outline-path \\='file
+;;         org-outline-path-complete-in-steps nil
+;;         org-refile-target-verify-function
+;;         #\\='vulpea-para-refile-verify-target)
+;;
+;; `vulpea-para-setup-defaults' wires all of this for you.
+;;
+;;; Code:
+
+(require 'org)
+(require 'seq)
+(require 'vulpea-note)
+(require 'vulpea-para-core)
+(require 'vulpea-para-db)
+
+(defcustom vulpea-para-refile-files-filter nil
+  "Predicate keeping refile candidate notes, or nil to keep all.
+
+Called with a file-level `vulpea-note'; return non-nil to keep it.  Use
+it to hold some notes (for example a cemetery, or generated files) out
+of the refile targets."
+  :type '(choice (const :tag "Keep all" nil)
+                 (function :tag "Predicate"))
+  :group 'vulpea-para)
+
+(defun vulpea-para-refile-files ()
+  "Return the file paths of all refile candidate notes.
+
+These are all live (not archived) file-level notes in the vault, with
+area files first so the PARA pillars surface at the top of the target
+list.  When `vulpea-para-refile-files-filter' is set, notes it rejects
+are left out.
+
+Use it as the FILES part of an `org-refile-targets' entry:
+
+  (setq org-refile-targets
+        \\='((vulpea-para-refile-files :maxlevel . 3)))"
+  (let ((notes (vulpea-para-resources)))
+    (when vulpea-para-refile-files-filter
+      (setq notes (seq-filter vulpea-para-refile-files-filter notes)))
+    (seq-uniq
+     (append
+      (mapcar #'vulpea-note-path (seq-filter #'vulpea-para-area-p notes))
+      (mapcar #'vulpea-note-path notes)))))
+
+(defun vulpea-para-refile-verify-target ()
+  "Return non-nil when the heading at point is a valid refile target.
+
+Archived headings are not, and the check moves point past the archived
+subtree so its children are never offered either.  Meant for
+`org-refile-target-verify-function'."
+  (if (member org-archive-tag (org-get-tags))
+      (progn (org-end-of-subtree t t) nil)
+    t))
+
+(provide 'vulpea-para-refile)
+;;; vulpea-para-refile.el ends here

--- a/vulpea-para.el
+++ b/vulpea-para.el
@@ -51,6 +51,7 @@
 ;; - `vulpea-para-agenda'  - the self-updating agenda, its views and
 ;;                          command building blocks.
 ;; - `vulpea-para-capture' - capture areas, projects, tasks, and meetings.
+;; - `vulpea-para-refile'  - refile targets covering the whole vault.
 ;; - `vulpea-para-find'    - find areas, projects, and resources.
 ;; - `vulpea-para-archive' - archive finished projects.
 ;; - `vulpea-para-doctor'  - find and report inconsistencies.
@@ -63,6 +64,7 @@
 (require 'vulpea-para-db)
 (require 'vulpea-para-agenda)
 (require 'vulpea-para-capture)
+(require 'vulpea-para-refile)
 (require 'vulpea-para-archive)
 (require 'vulpea-para-find)
 (require 'vulpea-para-doctor)
@@ -75,15 +77,22 @@
   "Install opinionated vulpea-para defaults.
 
 This is opt-in convenience.  It turns on `vulpea-para-agenda-mode' and
-sets `org-agenda-custom-commands', `org-agenda-prefix-format', and
-`org-capture-templates' from vulpea-para's building blocks, so you get a
-working agenda and capture out of the box.
+sets `org-agenda-custom-commands', `org-agenda-prefix-format',
+`org-capture-templates', and the refile options from vulpea-para's
+building blocks, so you get a working agenda, capture, and refile out
+of the box.
 
-It overwrites `org-agenda-custom-commands' and
-`org-agenda-prefix-format', and appends to `org-capture-templates'.
-The main agenda is named with `vulpea-para-agenda-main-buffer-name', and
-the meeting template clocks in.  Skip it and wire things by hand if you
-want full control over the layout (see the README)."
+It overwrites `org-agenda-custom-commands',
+`org-agenda-prefix-format', `org-refile-targets',
+`org-refile-use-outline-path', `org-outline-path-complete-in-steps',
+`org-refile-allow-creating-parent-nodes', and
+`org-refile-target-verify-function', and appends to
+`org-capture-templates'.  The main agenda is named with
+`vulpea-para-agenda-main-buffer-name', the meeting template clocks in,
+and refile reaches every live note in the vault (see
+`vulpea-para-refile-files'), not just the agenda files.  Skip it and
+wire things by hand if you want full control over the layout (see the
+README)."
   (vulpea-para-agenda-mode 1)
   (setq org-agenda-custom-commands
         `((" " "PARA agenda"
@@ -99,6 +108,11 @@ want full control over the layout (see the README)."
           (todo   . " %(vulpea-para-agenda-category 36) ")
           (tags   . " %(vulpea-para-agenda-category 36) ")
           (search . " %(vulpea-para-agenda-category 36) ")))
+  (setq org-refile-targets '((vulpea-para-refile-files :maxlevel . 3))
+        org-refile-use-outline-path 'file
+        org-outline-path-complete-in-steps nil
+        org-refile-allow-creating-parent-nodes 'confirm
+        org-refile-target-verify-function #'vulpea-para-refile-verify-target)
   (setq org-capture-templates
         (append
          org-capture-templates


### PR DESCRIPTION
Refiling from the agenda could only target the agenda files, and with the self-updating agenda those are just the files that already hold open work. So you could not refile a task into a quiet note, even though refiling is exactly how work reaches a note that had none.

org-refile-targets accepts a function as its FILES part, and this PR uses that hook. The new vulpea-para-refile module ships:

- vulpea-para-refile-files: every live file-level note from the database, area files first, for org-refile-targets
- vulpea-para-refile-files-filter: a predicate to keep some notes out of the target list (same shape as the agenda files filter)
- vulpea-para-refile-verify-target: for org-refile-target-verify-function, drops archived headings and skips their whole subtree

vulpea-para-setup-defaults wires all of it, including org-refile-use-outline-path 'file so a file itself is a valid target and a task can land at the top of an area or resource with no headings yet. Manual wiring is covered in the README, and getting-started has a new section on refiling.

Also drops "fancier refiling" from the roadmap, since this is it.