### PR TITLE
feat: answer refile targets from the database

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,8 @@
 
 * Unreleased
 
+- Refile target lists are now instant on large vaults. Org builds them by visiting every candidate file, which with =vulpea-para-refile-files= across a real vault meant minutes of "Getting targets..."; the new =vulpea-para-refile-mode= answers =org-refile-get-targets= straight from the database (=vulpea-para-refile-target-table=) with no file visits, whenever =org-refile-targets= is the single =vulpea-para-refile-files= entry. Everything else (org-goto, restricted refiles, foreign specs) falls through to org's own scan. =vulpea-para-setup-defaults= turns the mode on. Note that targets are now the vault's notes: a heading vulpea does not index is not offered.
+
 - Refile now reaches the whole vault, not just the agenda files. The new =vulpea-para-refile-files= plugs into =org-refile-targets= (org accepts a function as the FILES part) and returns every live file-level note from the database, area files first; =vulpea-para-refile-files-filter= keeps unwanted notes out, and the new =vulpea-para-refile-verify-target= (for =org-refile-target-verify-function=) drops archived subtrees from the candidates. =vulpea-para-setup-defaults= wires all of it, including =org-refile-use-outline-path 'file= so a file itself is a valid target.
 
 - =vulpea-para-agenda-mode= now maintains the =agenda= tag only for files in your vault (under =vulpea-db-sync-directories=), so Org files you edit elsewhere are left alone. The scope is configurable through the new =vulpea-para-agenda-tag-scope=; set it to a function that always returns non-nil to tag every Org buffer as before.

--- a/README.org
+++ b/README.org
@@ -29,7 +29,7 @@ And the nice part: these are facets, not walls. A note can be more than one at o
 
 - *Capture* into the right place without filing: a project under an area (=M-x vulpea-para-capture-project=), a new area (=M-x vulpea-para-capture-area=), and, through the Org capture building blocks (see below), tasks and meetings filed under the person they are about. Projects get a readable =Area > Project= category.
 - Lean on an *agenda that builds itself* from the notes that actually hold open work, in a few milliseconds even across thousands of notes: turn on =vulpea-para-agenda-mode=. Ready-made views come with it, =vulpea-para-agenda-main=, =-person=, and =-area=, plus command building blocks (=vulpea-para-agenda-cmd-*=) you splice into your own dispatcher.
-- *Refile* anywhere in the vault, right from the agenda: =vulpea-para-refile-files= feeds =org-refile-targets= every live note (areas first) instead of just the agenda files, and =vulpea-para-refile-verify-target= keeps archived subtrees out of the list.
+- *Refile* anywhere in the vault, right from the agenda: =vulpea-para-refile-files= feeds =org-refile-targets= every live note (areas first) instead of just the agenda files, and =vulpea-para-refile-mode= answers the target list from the database, so it is instant even at thousands of notes where org's own file scan would take minutes.
 - *Find* an area, a project, or a resource: =vulpea-para-find-area= and friends.
 - *Archive* a finished project into its area: =M-x vulpea-para-archive-project=.
 - Keep the whole thing honest with =M-x vulpea-para-doctor=.
@@ -97,11 +97,11 @@ Capture, again assembled by you:
 Refile, so a captured task can reach any note in the vault, not only the files that already carry open work (with the self-updating agenda, =org-agenda-files= is only the notes that hold work, so building refile targets from it would be backwards; refiling is exactly how work reaches a note that had none):
 
 #+begin_src emacs-lisp
+  (vulpea-para-refile-mode)
   (setq org-refile-targets '((vulpea-para-refile-files :maxlevel . 3))
         org-refile-use-outline-path 'file
         org-outline-path-complete-in-steps nil
-        org-refile-allow-creating-parent-nodes 'confirm
-        org-refile-target-verify-function #'vulpea-para-refile-verify-target)
+        org-refile-allow-creating-parent-nodes 'confirm)
 
   ;; and, like the agenda, the target list takes a filter
   (setq vulpea-para-refile-files-filter
@@ -109,7 +109,9 @@ Refile, so a captured task can reach any note in the vault, not only the files t
           (not (vulpea-note-tagged-any-p note "cemetery"))))
 #+end_src
 
-Targets are every live file-level note, area files first; =org-refile-use-outline-path 'file= makes a file itself a valid target, so a task can land at the top of an area or resource that has no headings yet. The verify function drops archived subtrees from the candidate list.
+Targets are every live note, area files first; =org-refile-use-outline-path 'file= makes a file itself a valid target, so a task can land at the top of an area or resource that has no headings yet.
+
+The mode is what makes this instant. Org normally builds the target list by visiting every candidate file, which takes minutes across a real vault; the database already knows every heading, its level, and its position, so =vulpea-para-refile-mode= answers =org-refile-get-targets= with one query (=vulpea-para-refile-target-table=) and touches no file. It only steps in when =org-refile-targets= is exactly the spec above; anything else (org-goto, a manually restricted refile) falls through to org's own scan. The flip side of reading from the database: targets are the vault's notes, so a heading vulpea does not index is not offered, and a file edited but not yet saved offers its last-synced positions (org detects the drift and asks you to retry). Without the mode the same spec still works on a small vault, scanned by org the slow way, with =vulpea-para-refile-verify-target= available for =org-refile-target-verify-function= to keep archived subtrees out.
 
 Then bind the commands you like: =vulpea-para-agenda-main=, =vulpea-para-agenda-person=, =vulpea-para-agenda-area=, =vulpea-para-capture-area=, =vulpea-para-capture-project=, =vulpea-para-find-area=, and the rest.
 

--- a/docs/getting-started.org
+++ b/docs/getting-started.org
@@ -64,7 +64,7 @@ Here is the part that scales. Walking thousands of notes to find the few with ta
 
 * Refiling into place
 
-Captured tasks pile up in an inbox, and the dispatcher's first block ("To refile") shows them. Press =C-c C-w= on one (in the agenda or in the file) and the target list covers your whole vault: every live note, area files first, by outline path. This matters because =org-agenda-files= is only the files that already hold open work; refiling is exactly how a task reaches a note that had none, so the targets come from the database instead. Archived subtrees stay out of the list.
+Captured tasks pile up in an inbox, and the dispatcher's first block ("To refile") shows them. Press =C-c C-w= on one (in the agenda or in the file) and the target list covers your whole vault: every live note, area files first, by outline path. This matters because =org-agenda-files= is only the files that already hold open work; refiling is exactly how a task reaches a note that had none, so the targets come from the database instead. That is also what keeps it instant: org would normally visit every candidate file to build the list, minutes of "Getting targets..." on a real vault, while the database answers in a moment without touching a file.
 
 =setup-defaults= wires this up. If a note should never be offered as a target, point =vulpea-para-refile-files-filter= at a predicate that rejects it.
 

--- a/test/vulpea-para-test.el
+++ b/test/vulpea-para-test.el
@@ -576,6 +576,109 @@ their own (org scans headings inside the returned files itself)."
            (lambda (n) (not (vulpea-note-tagged-any-p n "cemetery")))))
       (should (equal '("/tmp/blog.org") (vulpea-para-refile-files))))))
 
+(ert-deftest vulpea-para-refile-target-table-test ()
+  "The target table is built from the database, files not touched.
+
+Entries have the `org-refile-get-targets' shape: (TARGET FILE RE POS),
+one file entry plus one entry per heading, outline paths reconstructed
+from levels and positions, area files first."
+  (vulpea-para-test--with-temp-db
+    (vulpea-para-test--insert "r1" "Emacs" :level 0
+                              :path "/tmp/emacs.org" :pos 1)
+    (vulpea-para-test--insert "a1" "Blog" :level 0 :tags '("area")
+                              :path "/tmp/blog.org" :pos 1)
+    (vulpea-para-test--insert "h1" "Tasks" :level 1
+                              :path "/tmp/blog.org" :pos 100)
+    (vulpea-para-test--insert "h2" "Ship v2" :level 2 :tags '("project")
+                              :path "/tmp/blog.org" :pos 200)
+    (vulpea-para-test--insert "h3" "Notes" :level 1
+                              :path "/tmp/blog.org" :pos 50)
+    (let ((org-refile-use-outline-path 'file))
+      (should (equal
+               `(("blog.org" "/tmp/blog.org" nil nil)
+                 ("blog.org/Notes" "/tmp/blog.org" ,org-outline-regexp 50)
+                 ("blog.org/Tasks" "/tmp/blog.org" ,org-outline-regexp 100)
+                 ("blog.org/Tasks/Ship v2" "/tmp/blog.org" ,org-outline-regexp 200)
+                 ("emacs.org" "/tmp/emacs.org" nil nil))
+               (vulpea-para-refile-target-table))))))
+
+(ert-deftest vulpea-para-refile-target-table-levels-test ()
+  "The spec's :maxlevel and :level bound which headings are offered."
+  (vulpea-para-test--with-temp-db
+    (vulpea-para-test--insert "a1" "Blog" :level 0 :tags '("area")
+                              :path "/tmp/blog.org" :pos 1)
+    (vulpea-para-test--insert "h1" "Tasks" :level 1
+                              :path "/tmp/blog.org" :pos 100)
+    (vulpea-para-test--insert "h2" "Ship v2" :level 2 :tags '("project")
+                              :path "/tmp/blog.org" :pos 200)
+    (let ((org-refile-use-outline-path 'file))
+      ;; :maxlevel keeps deeper headings out
+      (should (equal
+               `(("blog.org" "/tmp/blog.org" nil nil)
+                 ("blog.org/Tasks" "/tmp/blog.org" ,org-outline-regexp 100))
+               (vulpea-para-refile-target-table '(:maxlevel . 1))))
+      ;; :level offers exactly that level, with full outline paths
+      (should (equal
+               `(("blog.org" "/tmp/blog.org" nil nil)
+                 ("blog.org/Tasks/Ship v2" "/tmp/blog.org"
+                  ,org-outline-regexp 200))
+               (vulpea-para-refile-target-table '(:level . 2))))
+      ;; the (KEY N) spelling org accepts works too
+      (should (equal (vulpea-para-refile-target-table '(:maxlevel . 1))
+                     (vulpea-para-refile-target-table '(:maxlevel 1)))))))
+
+(ert-deftest vulpea-para-refile-target-table-outline-path-styles-test ()
+  "Target strings follow `org-refile-use-outline-path'."
+  (vulpea-para-test--with-temp-db
+    (vulpea-para-test--insert "a1" "Blog" :level 0 :tags '("area")
+                              :path "/tmp/blog.org" :pos 1)
+    (vulpea-para-test--insert "h1" "A/B testing" :level 1
+                              :path "/tmp/blog.org" :pos 100)
+    ;; nil: bare heading text, no file entries
+    (let ((org-refile-use-outline-path nil))
+      (should (equal
+               `(("A/B testing" "/tmp/blog.org" ,org-outline-regexp 100))
+               (vulpea-para-refile-target-table))))
+    ;; t: outline path without the file, slashes escaped like org does
+    (let ((org-refile-use-outline-path t))
+      (should (equal
+               `(("A\\/B testing" "/tmp/blog.org" ,org-outline-regexp 100))
+               (vulpea-para-refile-target-table))))
+    ;; title: the note's title leads the path
+    (let ((org-refile-use-outline-path 'title))
+      (should (equal
+               `(("Blog" "/tmp/blog.org" nil nil)
+                 ("Blog/A\\/B testing" "/tmp/blog.org"
+                  ,org-outline-regexp 100))
+               (vulpea-para-refile-target-table))))))
+
+(ert-deftest vulpea-para-refile-mode-test ()
+  "The mode answers `org-refile-get-targets' from the database.
+
+When `org-refile-targets' is the vulpea-para spec, targets come from
+the target table and no file is visited; any other value falls through
+to org's own scan (here: the current buffer)."
+  (vulpea-para-test--with-temp-db
+    (vulpea-para-test--insert "a1" "Blog" :level 0 :tags '("area")
+                              :path "/tmp/does-not-exist-blog.org" :pos 1)
+    (unwind-protect
+        (progn
+          (vulpea-para-refile-mode 1)
+          (let ((org-refile-use-outline-path 'file)
+                (org-refile-targets
+                 '((vulpea-para-refile-files :maxlevel . 3))))
+            (should (equal (vulpea-para-refile-target-table '(:maxlevel . 3))
+                           (org-refile-get-targets))))
+          ;; unrelated targets fall through to org's own scanner
+          (with-temp-buffer
+            (org-mode)
+            (insert "* Local heading\n")
+            (let ((org-refile-use-outline-path nil)
+                  (org-refile-targets nil))
+              (should (equal "Local heading"
+                             (caar (org-refile-get-targets)))))))
+      (vulpea-para-refile-mode -1))))
+
 (ert-deftest vulpea-para-refile-verify-target-test ()
   "Archived headings are not refile targets; their subtree is skipped."
   (with-temp-buffer
@@ -594,8 +697,11 @@ their own (org scans headings inside the returned files itself)."
 
 (ert-deftest vulpea-para-setup-defaults-test ()
   "Setup-defaults installs the agenda commands and capture templates."
-  (cl-letf (((symbol-function 'vulpea-para-agenda-mode) #'ignore))
-    (let ((vulpea-para-agenda-main-buffer-name "*test agenda*")
+  (let (refile-mode-arg)
+    (cl-letf (((symbol-function 'vulpea-para-agenda-mode) #'ignore)
+              ((symbol-function 'vulpea-para-refile-mode)
+               (lambda (arg) (setq refile-mode-arg arg))))
+      (let ((vulpea-para-agenda-main-buffer-name "*test agenda*")
           org-agenda-custom-commands
           org-agenda-prefix-format
           org-capture-templates
@@ -614,6 +720,8 @@ their own (org scans headings inside the returned files itself)."
       (should (eq 'confirm org-refile-allow-creating-parent-nodes))
       (should (eq #'vulpea-para-refile-verify-target
                   org-refile-target-verify-function))
+      ;; and the targets are answered from the database
+      (should (equal 1 refile-mode-arg))
       (should (assoc "p" org-capture-templates))
       (should (assoc "m" org-capture-templates))
       (should org-agenda-prefix-format)
@@ -625,7 +733,7 @@ their own (org scans headings inside the returned files itself)."
       (should (plist-get (nthcdr 5 (assoc "m" org-capture-templates))
                          :clock-in))
       (should (plist-get (nthcdr 5 (assoc "m" org-capture-templates))
-                         :clock-resume)))))
+                         :clock-resume))))))
 
 (provide 'vulpea-para-test)
 ;;; vulpea-para-test.el ends here

--- a/vulpea-para-refile.el
+++ b/vulpea-para-refile.el
@@ -33,13 +33,25 @@
 ;;         org-refile-target-verify-function
 ;;         #\\='vulpea-para-refile-verify-target)
 ;;
+;; That alone is not enough at scale, though.  Org builds its target
+;; table by visiting every file in the list, and at a few hundred
+;; milliseconds per note file a real vault takes minutes.  The database
+;; already knows every heading, its position, and its level, so
+;; `vulpea-para-refile-mode' answers `org-refile-get-targets' straight
+;; from a query (see `vulpea-para-refile-target-table') whenever
+;; `org-refile-targets' is the spec above, and touches no file at all.
+;; Any other value of `org-refile-targets', including the let-bound ones
+;; org-goto uses, falls through to org's own scan.
+;;
 ;; `vulpea-para-setup-defaults' wires all of this for you.
 ;;
 ;;; Code:
 
 (require 'org)
+(require 'org-refile)
 (require 'seq)
 (require 'vulpea-note)
+(require 'vulpea-db-query)
 (require 'vulpea-para-core)
 (require 'vulpea-para-db)
 
@@ -53,6 +65,21 @@ of the refile targets."
                  (function :tag "Predicate"))
   :group 'vulpea-para)
 
+(defun vulpea-para-refile--file-paths (notes)
+  "Order and filter file-level NOTES into refile candidate paths.
+
+Keeps the live (not archived) file-level notes, drops the ones
+`vulpea-para-refile-files-filter' rejects, and returns their paths with
+area files first so the PARA pillars surface at the top of the target
+list."
+  (let ((notes (seq-filter #'vulpea-para-resource-p notes)))
+    (when vulpea-para-refile-files-filter
+      (setq notes (seq-filter vulpea-para-refile-files-filter notes)))
+    (seq-uniq
+     (append
+      (mapcar #'vulpea-note-path (seq-filter #'vulpea-para-area-p notes))
+      (mapcar #'vulpea-note-path notes)))))
+
 (defun vulpea-para-refile-files ()
   "Return the file paths of all refile candidate notes.
 
@@ -65,13 +92,7 @@ Use it as the FILES part of an `org-refile-targets' entry:
 
   (setq org-refile-targets
         \\='((vulpea-para-refile-files :maxlevel . 3)))"
-  (let ((notes (vulpea-para-resources)))
-    (when vulpea-para-refile-files-filter
-      (setq notes (seq-filter vulpea-para-refile-files-filter notes)))
-    (seq-uniq
-     (append
-      (mapcar #'vulpea-note-path (seq-filter #'vulpea-para-area-p notes))
-      (mapcar #'vulpea-note-path notes)))))
+  (vulpea-para-refile--file-paths (vulpea-db-query-by-level 0)))
 
 (defun vulpea-para-refile-verify-target ()
   "Return non-nil when the heading at point is a valid refile target.
@@ -82,6 +103,149 @@ subtree so its children are never offered either.  Meant for
   (if (member org-archive-tag (org-get-tags))
       (progn (org-end-of-subtree t t) nil)
     t))
+
+;;; The database-backed target table
+;;
+;; Org builds refile targets by visiting every candidate file, which is
+;; hopeless across a whole vault.  Everything org wants in that table
+;; (heading text, file, position, level) is already in the database, so
+;; we build the same table with one query and no file visits.
+
+(defun vulpea-para-refile--spec-levels (spec)
+  "Return the (MIN . MAX) heading levels SPEC asks for, or nil.
+
+SPEC is the SPECIFICATION part of an `org-refile-targets' entry.  Only
+the level-based ones can be answered from the database: t, `:maxlevel',
+and `:level' (in both the dotted and the plain-list spelling org
+accepts).  For anything else, nil: the caller falls back to org's own
+file scan."
+  ;; normalize (KEY N) to (KEY . N), as org does
+  (when (and (listp spec) (listp (cdr spec)) (null (cddr spec)))
+    (setq spec (cons (car spec) (cadr spec))))
+  (pcase spec
+    (`t (cons 1 most-positive-fixnum))
+    (`(:maxlevel . ,(and (pred integerp) n)) (cons 1 n))
+    (`(:level . ,(and (pred integerp) n)) (cons n n))))
+
+(defun vulpea-para-refile--file-targets (path notes levels)
+  "Return the target-table entries for the file PATH.
+
+NOTES are the notes living in PATH (any levels, any order); LEVELS is
+a (MIN . MAX) cons bounding which heading levels become targets.
+Outline paths are reconstructed from the notes' levels and positions,
+and the target strings follow `org-refile-use-outline-path'."
+  (let* ((style org-refile-use-outline-path)
+         (file-note (seq-find (lambda (n) (= 0 (vulpea-note-level n))) notes))
+         (base (pcase style
+                 (`file (file-name-nondirectory path))
+                 (`full-file-path path)
+                 (`title (or (and file-note (vulpea-note-title file-note))
+                             (file-name-nondirectory path)))
+                 (`buffer-name (if-let* ((buf (find-buffer-visiting path)))
+                                   (buffer-name buf)
+                                 (file-name-nondirectory path)))
+                 (_ nil)))
+         (headings (sort (seq-filter (lambda (n) (> (vulpea-note-level n) 0))
+                                     notes)
+                         (lambda (a b) (< (vulpea-note-pos a)
+                                          (vulpea-note-pos b)))))
+         (stack nil)
+         (targets nil))
+    ;; the file itself is a target under the file-naming styles, just
+    ;; like in `org-refile-get-targets'
+    (when base
+      (push (list base path nil nil) targets))
+    (dolist (note headings)
+      (let ((level (vulpea-note-level note)))
+        (while (and stack (>= (caar stack) level))
+          (pop stack))
+        (push (cons level (vulpea-note-title note)) stack)
+        (when (and (<= (car levels) level) (<= level (cdr levels)))
+          (let ((olp (mapcar (lambda (s)
+                               (replace-regexp-in-string "/" "\\/" s nil t))
+                             (reverse (mapcar #'cdr stack)))))
+            (push (list (if style
+                            (mapconcat #'identity
+                                       (if base (cons base olp) olp)
+                                       "/")
+                          (vulpea-note-title note))
+                        path
+                        ;; a loose position check: DB titles are
+                        ;; normalized (links stripped), so org's exact
+                        ;; heading regexp would reject valid targets;
+                        ;; "still a heading here" catches stale
+                        ;; positions all the same
+                        org-outline-regexp
+                        (vulpea-note-pos note))
+                  targets)))))
+    (nreverse targets)))
+
+(defun vulpea-para-refile-target-table (&optional spec)
+  "Build a refile target table from the database.
+
+The result has the shape `org-refile-get-targets' produces, a list of
+\(TARGET FILE REGEXP POSITION) entries: one entry per file (under the
+file-naming `org-refile-use-outline-path' styles) plus one per heading
+the database knows in it, grouped by file with area files first.  No
+file is visited; positions and outline paths come straight from the
+database, which also means the targets are the vault's *notes*: a
+heading vulpea does not index is not offered.
+
+SPEC is the SPECIFICATION part of an `org-refile-targets' entry and
+must be level-based (see `vulpea-para-refile--spec-levels'); it
+defaults to (:maxlevel . 3).
+
+One query fetches every note; asking the database per file, or even
+for the file subset, turned out an order of magnitude slower on a real
+vault than filtering the full set here."
+  (let ((levels (or (vulpea-para-refile--spec-levels (or spec '(:maxlevel . 3)))
+                    (user-error "Unsupported refile spec: %S" spec)))
+        ;; materializing thousands of notes churns the GC hard enough
+        ;; to triple the build time; defer it for the duration
+        (gc-cons-threshold most-positive-fixnum))
+    (let ((notes (vulpea-db-query))
+          (by-path (make-hash-table :test #'equal)))
+      (dolist (note notes)
+        (push note (gethash (vulpea-note-path note) by-path)))
+      (mapcan (lambda (path)
+                (vulpea-para-refile--file-targets
+                 path (gethash path by-path) levels))
+              (vulpea-para-refile--file-paths
+               (seq-filter (lambda (n) (= 0 (vulpea-note-level n))) notes))))))
+
+(defun vulpea-para-refile--get-targets (orig &rest args)
+  "Answer `org-refile-get-targets' from the database when possible.
+
+When `org-refile-targets' is a single `vulpea-para-refile-files' entry
+with a level-based spec, return `vulpea-para-refile-target-table'
+without touching a file.  Anything else, including the values org-goto
+and friends let-bind, goes to ORIG (with ARGS) untouched."
+  (let ((entry (and (null (cdr org-refile-targets))
+                    (car-safe org-refile-targets))))
+    (if (and (consp entry)
+             (eq (car entry) 'vulpea-para-refile-files)
+             (vulpea-para-refile--spec-levels (cdr entry)))
+        (vulpea-para-refile-target-table (cdr entry))
+      (apply orig args))))
+
+;;;###autoload
+(define-minor-mode vulpea-para-refile-mode
+  "Answer refile targets from the database instead of scanning files.
+
+Org builds its refile target table by visiting every candidate file,
+which takes minutes across a whole vault.  With this mode on,
+`org-refile-get-targets' is answered by a database query (see
+`vulpea-para-refile-target-table') whenever `org-refile-targets' is
+the vulpea-para spec, a single `vulpea-para-refile-files' entry; any
+other value falls through to org's own scan, so org-goto and manual
+restrictions keep working."
+  :global t
+  :group 'vulpea-para
+  (if vulpea-para-refile-mode
+      (advice-add 'org-refile-get-targets :around
+                  #'vulpea-para-refile--get-targets)
+    (advice-remove 'org-refile-get-targets
+                   #'vulpea-para-refile--get-targets)))
 
 (provide 'vulpea-para-refile)
 ;;; vulpea-para-refile.el ends here

--- a/vulpea-para.el
+++ b/vulpea-para.el
@@ -90,9 +90,11 @@ It overwrites `org-agenda-custom-commands',
 `org-capture-templates'.  The main agenda is named with
 `vulpea-para-agenda-main-buffer-name', the meeting template clocks in,
 and refile reaches every live note in the vault (see
-`vulpea-para-refile-files'), not just the agenda files.  Skip it and
-wire things by hand if you want full control over the layout (see the
-README)."
+`vulpea-para-refile-files'), not just the agenda files.  It also turns
+on `vulpea-para-refile-mode', which answers the refile target list
+from the database instead of letting org visit every file.  Skip it
+and wire things by hand if you want full control over the layout (see
+the README)."
   (vulpea-para-agenda-mode 1)
   (setq org-agenda-custom-commands
         `((" " "PARA agenda"
@@ -108,6 +110,7 @@ README)."
           (todo   . " %(vulpea-para-agenda-category 36) ")
           (tags   . " %(vulpea-para-agenda-category 36) ")
           (search . " %(vulpea-para-agenda-category 36) ")))
+  (vulpea-para-refile-mode 1)
   (setq org-refile-targets '((vulpea-para-refile-files :maxlevel . 3))
         org-refile-use-outline-path 'file
         org-outline-path-complete-in-steps nil


### PR DESCRIPTION
Follow-up to #7, which turned out unusable on a real vault: org builds the refile target table by visiting every candidate file, and at ~250ms per note file a 1579-file vault sits in "Getting targets..." for about 7 minutes.

The database already knows every heading, its level, and its position, so this builds the same (TARGET FILE RE POS) table org produces, with one query and zero file visits. The new vulpea-para-refile-mode installs it as around-advice on org-refile-get-targets and only steps in when org-refile-targets is the single vulpea-para-refile-files entry with a level-based spec (:maxlevel / :level / t); anything else, including the let-bound targets org-goto uses, falls through to org untouched. setup-defaults turns the mode on.

Details worth knowing:

- the position-check regexp is a loose "still a heading here" instead of org's exact-title one, because DB titles are normalized (links stripped from headings) and the exact regexp would falsely reject ~5% of targets
- GC is deferred during the build; materializing thousands of notes otherwise triples the time
- targets are now the vault's notes: a heading vulpea does not index is not offered
- measured on the real vault: 4416 targets in ~1.2s instead of ~7 minutes

Verified live against a 1579-file vault via emacsclient, plus the usual ERT coverage.