### PR TITLE
feat: complete refile targets by note title, not file name

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,8 @@
 
 * Unreleased
 
+- Refile targets now complete by note *title* instead of file name: =vulpea-para-setup-defaults= sets =org-refile-use-outline-path= to ='title=, so a target reads as =Barberry Garden/Tasks= rather than =20240807084021-barberry_garden.org/Tasks=. File names drift away from what a note is called while titles keep up. Set it back to ='file= if you prefer file names.
+
 - Refile target lists are now instant on large vaults. Org builds them by visiting every candidate file, which with =vulpea-para-refile-files= across a real vault meant minutes of "Getting targets..."; the new =vulpea-para-refile-mode= answers =org-refile-get-targets= straight from the database (=vulpea-para-refile-target-table=) with no file visits, whenever =org-refile-targets= is the single =vulpea-para-refile-files= entry. Everything else (org-goto, restricted refiles, foreign specs) falls through to org's own scan. =vulpea-para-setup-defaults= turns the mode on. Note that targets are now the vault's notes: a heading vulpea does not index is not offered.
 
 - Refile now reaches the whole vault, not just the agenda files. The new =vulpea-para-refile-files= plugs into =org-refile-targets= (org accepts a function as the FILES part) and returns every live file-level note from the database, area files first; =vulpea-para-refile-files-filter= keeps unwanted notes out, and the new =vulpea-para-refile-verify-target= (for =org-refile-target-verify-function=) drops archived subtrees from the candidates. =vulpea-para-setup-defaults= wires all of it, including =org-refile-use-outline-path 'file= so a file itself is a valid target.

--- a/README.org
+++ b/README.org
@@ -99,7 +99,7 @@ Refile, so a captured task can reach any note in the vault, not only the files t
 #+begin_src emacs-lisp
   (vulpea-para-refile-mode)
   (setq org-refile-targets '((vulpea-para-refile-files :maxlevel . 3))
-        org-refile-use-outline-path 'file
+        org-refile-use-outline-path 'title
         org-outline-path-complete-in-steps nil
         org-refile-allow-creating-parent-nodes 'confirm)
 
@@ -109,7 +109,7 @@ Refile, so a captured task can reach any note in the vault, not only the files t
           (not (vulpea-note-tagged-any-p note "cemetery"))))
 #+end_src
 
-Targets are every live note, area files first; =org-refile-use-outline-path 'file= makes a file itself a valid target, so a task can land at the top of an area or resource that has no headings yet.
+Targets are every live note, area files first, and they complete by *title*: a target reads as =Barberry Garden/Tasks=, not =20240807084021-barberry_garden.org/Tasks=, because file names drift away from what a note is called while titles keep up (prefer file names anyway? set =org-refile-use-outline-path= to ='file=). The file itself is a valid target too, so a task can land at the top of an area or resource that has no headings yet.
 
 The mode is what makes this instant. Org normally builds the target list by visiting every candidate file, which takes minutes across a real vault; the database already knows every heading, its level, and its position, so =vulpea-para-refile-mode= answers =org-refile-get-targets= with one query (=vulpea-para-refile-target-table=) and touches no file. It only steps in when =org-refile-targets= is exactly the spec above; anything else (org-goto, a manually restricted refile) falls through to org's own scan. The flip side of reading from the database: targets are the vault's notes, so a heading vulpea does not index is not offered, and a file edited but not yet saved offers its last-synced positions (org detects the drift and asks you to retry). Without the mode the same spec still works on a small vault, scanned by org the slow way, with =vulpea-para-refile-verify-target= available for =org-refile-target-verify-function= to keep archived subtrees out.
 

--- a/docs/getting-started.org
+++ b/docs/getting-started.org
@@ -64,7 +64,7 @@ Here is the part that scales. Walking thousands of notes to find the few with ta
 
 * Refiling into place
 
-Captured tasks pile up in an inbox, and the dispatcher's first block ("To refile") shows them. Press =C-c C-w= on one (in the agenda or in the file) and the target list covers your whole vault: every live note, area files first, by outline path. This matters because =org-agenda-files= is only the files that already hold open work; refiling is exactly how a task reaches a note that had none, so the targets come from the database instead. That is also what keeps it instant: org would normally visit every candidate file to build the list, minutes of "Getting targets..." on a real vault, while the database answers in a moment without touching a file.
+Captured tasks pile up in an inbox, and the dispatcher's first block ("To refile") shows them. Press =C-c C-w= on one (in the agenda or in the file) and the target list covers your whole vault: every live note, area files first, completed by the note's *title* (not its file name), with headings as =Title/Heading= paths. This matters because =org-agenda-files= is only the files that already hold open work; refiling is exactly how a task reaches a note that had none, so the targets come from the database instead. That is also what keeps it instant: org would normally visit every candidate file to build the list, minutes of "Getting targets..." on a real vault, while the database answers in a moment without touching a file.
 
 =setup-defaults= wires this up. If a note should never be offered as a target, point =vulpea-para-refile-files-filter= at a predicate that rejects it.
 

--- a/test/vulpea-para-test.el
+++ b/test/vulpea-para-test.el
@@ -712,10 +712,12 @@ to org's own scan (here: the current buffer)."
           org-refile-target-verify-function)
       (vulpea-para-setup-defaults)
       (should (assoc " " org-agenda-custom-commands))
-      ;; refile sees the whole vault, by outline path, minus archives
+      ;; refile sees the whole vault, by title path, minus archives
       (should (equal '((vulpea-para-refile-files :maxlevel . 3))
                      org-refile-targets))
-      (should (eq 'file org-refile-use-outline-path))
+      ;; titles, not file names: file names drift away from what a
+      ;; note is called, and nobody remembers them
+      (should (eq 'title org-refile-use-outline-path))
       (should-not org-outline-path-complete-in-steps)
       (should (eq 'confirm org-refile-allow-creating-parent-nodes))
       (should (eq #'vulpea-para-refile-verify-target

--- a/vulpea-para.el
+++ b/vulpea-para.el
@@ -112,7 +112,9 @@ the README)."
           (search . " %(vulpea-para-agenda-category 36) ")))
   (vulpea-para-refile-mode 1)
   (setq org-refile-targets '((vulpea-para-refile-files :maxlevel . 3))
-        org-refile-use-outline-path 'file
+        ;; titles, not file names: file names drift away from what a
+        ;; note is called by now, and nobody remembers them
+        org-refile-use-outline-path 'title
         org-outline-path-complete-in-steps nil
         org-refile-allow-creating-parent-nodes 'confirm
         org-refile-target-verify-function #'vulpea-para-refile-verify-target)


### PR DESCRIPTION
Small follow-up to #8. Targets completed as 20240807084021-barberry_garden.org/Tasks, which is hostile: file names freeze the title at creation time and drift away from what the note is called now, and nobody remembers them.

org-refile-use-outline-path 'title fixes exactly this, and the DB-backed target table already supports it (the file-level note's title leads the path, file name as fallback). This just flips setup-defaults to 'title, so targets read as Barberry Garden/Tasks. Anyone who prefers file names can set 'file back in their config.