### PR TITLE
fix: resolve symlinks in vulpea-para-vault-buffer-p

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,8 @@
 
 * Unreleased
 
+- =vulpea-para-agenda-mode= now tags files whose vault is reached through a symlink. =vulpea-para-vault-buffer-p= compared =expand-file-name= prefixes, which do not resolve symlinks, so a vault behind a link (a Termux storage link, an iCloud or Dropbox path) failed the scope check even though the database indexed it fine: files never picked up the =agenda= tag on save (#6). Both sides are resolved with =file-truename= now, so it matches whichever side carries the link.
+
 - The agenda now tells you when it is missing files, and the new =vulpea-para-agenda-backfill= fixes it in one go. The =agenda= tag is maintained on save, so open work that predates =vulpea-para-agenda-mode= (or was last saved without it) never made it onto the agenda: TODOs showed in =vulpea-para-agenda-area= but not in the main views (#6). The first agenda build of a session now checks the database for such files (a fast query, no file visits) and points at the backfill command; =vulpea-para-agenda-warn-missing= turns the check off. The backfill visits only the affected files, re-runs the save-time open-work check there, and saves the ones that change, so a stale database row never mis-tags a file. =vulpea-para-agenda-missing-files= is the underlying query, and =vulpea-para-done-keywords= (with the open-note predicate) moved from the doctor into the agenda module, where both now use it.
 
 - Refile targets now complete by note *title* instead of file name: =vulpea-para-setup-defaults= sets =org-refile-use-outline-path= to ='title=, so a target reads as =Barberry Garden/Tasks= rather than =20240807084021-barberry_garden.org/Tasks=. File names drift away from what a note is called while titles keep up. Set it back to ='file= if you prefer file names.

--- a/test/vulpea-para-test.el
+++ b/test/vulpea-para-test.el
@@ -304,6 +304,38 @@
       (setq buffer-file-name "/tmp/vault/note.org")
       (should-not (vulpea-para-vault-buffer-p)))))
 
+(ert-deftest vulpea-para-vault-buffer-p-symlink-test ()
+  "A vault reached through a symlink still counts, either side linked.
+
+Termux and iCloud/Dropbox setups reach the vault through a symlink, so
+the buffer's truename and the configured directory disagree on the
+symlink; the scope check has to resolve both before comparing."
+  (let* ((real (file-truename (make-temp-file "vp-vault-real-" t)))
+         (link (concat (file-truename
+                        (make-temp-file "vp-vault-link-" t))
+                       "/vault")))
+    (unwind-protect
+        (progn
+          (make-symbolic-link real link)
+          ;; sync dir is the symlink, the buffer visits the real path
+          (let ((vulpea-db-sync-directories (list link)))
+            (with-temp-buffer
+              (setq buffer-file-name (expand-file-name "note.org" real))
+              (should (vulpea-para-vault-buffer-p))))
+          ;; sync dir is the real path, the buffer visits the symlink
+          (let ((vulpea-db-sync-directories (list real)))
+            (with-temp-buffer
+              (setq buffer-file-name (expand-file-name "note.org" link))
+              (should (vulpea-para-vault-buffer-p))))
+          ;; a file outside the vault is still rejected
+          (let ((vulpea-db-sync-directories (list link)))
+            (with-temp-buffer
+              (setq buffer-file-name "/tmp/elsewhere/readme.org")
+              (should-not (vulpea-para-vault-buffer-p)))))
+      (when (file-symlink-p link) (delete-file link))
+      (delete-directory real t)
+      (delete-directory (file-name-directory link) t))))
+
 (ert-deftest vulpea-para-maybe-update-agenda-tag-scope-test ()
   "The save-time updater only tags buffers the scope predicate accepts."
   ;; scope rejects the buffer -> no agenda tag even with open work

--- a/vulpea-para-agenda.el
+++ b/vulpea-para-agenda.el
@@ -403,13 +403,17 @@ Handy in `org-agenda-prefix-format', for example:
 A file is in the vault when it lives under one of
 `vulpea-db-sync-directories'.  This is the default scope for
 `vulpea-para-agenda-mode', so Org files you edit outside your notes are
-never touched."
+never touched.
+
+Both sides are resolved with `file-truename' before comparing, so a
+vault reached through a symlink (a Termux storage link, an iCloud or
+Dropbox path) still matches when only one side carries the link."
   (when-let* ((file (buffer-file-name))
               (dirs (bound-and-true-p vulpea-db-sync-directories)))
-    (let ((file (expand-file-name file)))
+    (let ((file (file-truename file)))
       (seq-some
        (lambda (dir)
-         (string-prefix-p (file-name-as-directory (expand-file-name dir))
+         (string-prefix-p (file-name-as-directory (file-truename dir))
                           file))
        dirs))))
 


### PR DESCRIPTION
Follow-up to #6.

The reporter is on Termux, where the vault is reached through a symlink (`~/storage/shared/...`). Their diagnostics pinned it down: the save hook was installed and open work was detected, but `vulpea-para-vault-buffer-p` returned nil, so the scope check rejected the file and it never got the agenda tag on save. The backfill worked because it applies the tag directly from database paths and skips the scope check.

The predicate compared `expand-file-name` prefixes, which do not resolve symlinks: the buffer's path had the link resolved while the configured directory did not, so the prefix never matched. This bites any symlinked vault (Termux storage links, iCloud, Dropbox).

Resolve both sides with `file-truename` before comparing, so it matches whichever side carries the link. Added a test that builds a real symlink and checks both directions.

Side note: vulpea core does the same directory-membership check in two places, one symlink-safe (`file-in-directory-p` in cleanup) and one not (the fswatch path filter). Worth a public predicate there eventually; will file separately.